### PR TITLE
optionally don't write downloaded data to disk

### DIFF
--- a/boto3/multithread_upload/uh_upload.py
+++ b/boto3/multithread_upload/uh_upload.py
@@ -72,7 +72,6 @@ class RandomDataStream(io.BytesIO):
             size = self.remaining
         self.remaining -= size
         return bytearray(os.urandom(size))
-        #return random.randbytes(size)
 
     def seekable(self):
         return False


### PR DESCRIPTION
The --no-store argument has been added for benchmarking download performance. With the argument provided, the download script only downloads data but does not store it to persistent storage. 