### PR TITLE
EKS cluster upgrade to 1.32

### DIFF
--- a/terraform/aws/eks-cluster-controllers/controllers.tf
+++ b/terraform/aws/eks-cluster-controllers/controllers.tf
@@ -87,7 +87,7 @@ resource "helm_release" "karpenter" {
   namespace  = local.karpenter_namespace
   repository = "oci://public.ecr.aws/karpenter"
   chart      = "karpenter"
-  version    = "0.35.1"
+  version    = "1.2.0"
 
   values = [
     data.template_file.karpenter.rendered

--- a/terraform/aws/eks-cluster-controllers/karpenter-manifests/10TB.node-pool.yaml
+++ b/terraform/aws/eks-cluster-controllers/karpenter-manifests/10TB.node-pool.yaml
@@ -1,4 +1,4 @@
-apiVersion: karpenter.sh/v1beta1
+apiVersion: karpenter.sh/v1
 kind: NodePool
 metadata:
   name: ultihash-node
@@ -12,7 +12,7 @@ spec:
         purpose: 10TB
     spec:
       nodeClassRef:
-        apiVersion: karpenter.k8s.aws/v1beta1
+        group: karpenter.k8s.aws
         kind: EC2NodeClass
         name: ultihash-testing
       requirements:

--- a/terraform/aws/eks-cluster-controllers/karpenter-manifests/ec2.node-class.yaml
+++ b/terraform/aws/eks-cluster-controllers/karpenter-manifests/ec2.node-class.yaml
@@ -1,9 +1,10 @@
-apiVersion: karpenter.k8s.aws/v1beta1
+apiVersion: karpenter.k8s.aws/v1
 kind: EC2NodeClass
 metadata:
   name: ultihash-testing
 spec:
-  amiFamily: Bottlerocket
+  amiSelectorTerms:
+    - alias: bottlerocket@v1.32.0
   role: ${node_registration_role}
   subnetSelectorTerms:
     - tags:

--- a/terraform/aws/eks-cluster/config.tfvars
+++ b/terraform/aws/eks-cluster/config.tfvars
@@ -10,7 +10,7 @@ vpc_private_subnets = ["10.0.16.0/20", "10.0.32.0/20"]   # IPv4 ranges allocated
 # EKS cluster configuration
 
 cluster_name    = "ultihash-test" # Human readable name for the EKS cluster
-cluster_version = "1.30"          # Kubernetes engine version for the EKS cluster
+cluster_version = "1.32"          # Kubernetes engine version for the EKS cluster
 
 cluster_admins = [
   "arn:aws:iam::account_id:user/test-user" # REQUIRED TO CHANGE: List of IAM roles or IAM users to grant admin access to the EKS cluster

--- a/terraform/aws/eks-cluster/eks.tf
+++ b/terraform/aws/eks-cluster/eks.tf
@@ -41,13 +41,13 @@ module "eks" {
   # Setup the essential cluster controllers
   cluster_addons = {
     vpc-cni = {
-      addon_version = "v1.18.1-eksbuild.3"
+      most_recent = true
     }
     kube-proxy = {
-      addon_version = "v1.30.0-eksbuild.3"
+      most_recent = true
     }
     coredns = {
-      addon_version = "v1.10.1-eksbuild.7"
+      most_recent = true
     }
   }
 


### PR DESCRIPTION
Upgraded EKS cluster to a newer version 1.32 as well as Karpenter deployment to function correctly 